### PR TITLE
non-privileged install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ gradle_download_url: "https://services.gradle.org/distributions/{{ gradle_binary
 gradle_base_dir: /usr/local/share/
 gradle_extract_dir:  "gradle-{{ gradle_version }}"
 gradle_link: /usr/local/bin/gradle
+gradle_user_install: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,8 +35,6 @@
     file:
       src: "{{ gradle_base_dir }}/{{ gradle_extract_dir }}/bin/gradle"
       dest: "{{ gradle_link }}"
-      owner: root
-      group: root
       state: link
 
   - name: "Validate Gradle version"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,11 @@
       name: unzip
       state: latest
 
+  - name: "Ensure base dir exists"
+    file:
+      path: "{{ gradle_base_dir }}"
+      state: directory
+
   - name: "Download"
     get_url:
       url: "{{ gradle_download_url }}"
@@ -30,6 +35,11 @@
       src: "{{ gradle_download }}"
       dest: "{{ gradle_base_dir }}"
       remote_src: True
+
+  - name: "Ensure symlink basedir exists"
+    file:
+      path: "{{ gradle_link | dirname }}"
+      state: directory
 
   - name: "Add gradle symlink to path"
     file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
     package:
       name: unzip
       state: latest
+    when: not gradle_user_install
 
   - name: "Ensure base dir exists"
     file:


### PR DESCRIPTION
This pull request facilitates non-privileged install, by setting a new gradle_user_install parameter to yes, and setting the install locations to user-accessible locations.
The non-privileged install avoids installing the unzip package on the system, and just assumes it is there.